### PR TITLE
Allow origin * for /llms.txt

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   from = "/"
   to = "/docs/welcome/"
   status = 301
+
+[[headers]]
+  for = "/llms.txt"
+  [headers.values]
+    access-control-allow-origin = "*"


### PR DESCRIPTION
Truth be told I have not tested this. (I do have a CORS error from doing this now, though, so I'll be able to tell if it works.)