### PR TITLE
React tutorial tsx

### DIFF
--- a/docs/react-tutorial.md
+++ b/docs/react-tutorial.md
@@ -19,7 +19,7 @@ npm create vite@latest my-vite-fp-tutorial
 cd my-vite-fp-tutorial
 ```
 
-This app will manage todos. There's no schema to set up -- you can use TypeScript to enforce schemas, see [the React TypeScript Starter Kit for examples](https://github.com/fireproof-storage/fireproof-starter-kit-react-ts-vite). Instead we just start with a query that returns nothing, and a form that writes the documents to the ledger. In plain JavaScript apps, you can subscribe your `redraw()` function to the ledger, or inspect the update stream and surgically update the parts of the page that need to change. In React, you don't have to worry about any of that, the hooks will do it for you.
+This app will manage todos. There's no schema to set up -- you can use TypeScript to enforce schemas, see [the React TypeScript Starter Kit for examples](https://github.com/fireproof-storage/fireproof-starter-kit-react-ts-vite). Instead we just start with a query that returns nothing, and a form that writes the documents to the database. In plain JavaScript apps, you can subscribe your `redraw()` function to the database, or inspect the update stream and surgically update the parts of the page that need to change. In React, you don't have to worry about any of that, the hooks will do it for you.
 
 ### The Data Model
 
@@ -60,7 +60,7 @@ The first step is to import the hooks into your new app. In `src/App.tsx`, add t
 import { useFireproof } from 'use-fireproof'
 ```
 
-This hook provides access to `useLiveQuery` and `useDocument` configured for your application. The hooks will automatically initiate a browser-local copy of the ledger and begin development. The `useLiveQuery` hook will automatically refresh query results, and the `useDocument` hook loads and saves Fireproof documents and handles refreshing them when data changes.
+This hook provides access to `useLiveQuery` and `useDocument` configured for your application. The hooks will automatically initiate a browser-local copy of the database and begin development. The `useLiveQuery` hook will automatically refresh query results, and the `useDocument` hook loads and saves Fireproof documents and handles refreshing them when data changes.
 
 Fireproof takes a build-first approach, so after your UI is running, you can connect to your cloud of choice. For now, let's build the app.
 
@@ -118,13 +118,13 @@ const { doc: todo, merge: mergeTodo, save: saveTodo, reset: resetTodo } = useDoc
 }));
 ```
 
-The return value is essentially the return value of [`useState`](https://react.dev/reference/react/useState) but with a save document function added, in this case called `saveTodo`. A very common pattern in React is to use a state variable and a setter function to manage the state of a form. This hook is a convenience for that pattern, but it also handles saving the document to the ledger.
+The return value is essentially the return value of [`useState`](https://react.dev/reference/react/useState) but with a save document function added, in this case called `saveTodo`. A very common pattern in React is to use a state variable and a setter function to manage the state of a form. This hook is a convenience for that pattern, but it also handles saving the document to the database.
 
-The `useDocument` hook is used to create a new document with an empty `text` field. The `saveTodo` function is called when the form is submitted, and it saves the document to the ledger. The `mergeTodo` function is used to update the `text` field as the user types. 
+The `useDocument` hook is used to create a new document with an empty `text` field. The `saveTodo` function is called when the form is submitted, and it saves the document to the database. The `mergeTodo` function is used to update the `text` field as the user types. 
 
 ### Save the Todo
 
-Here is the code that renders the form. The common React pattern described above is used here: the input field is bound to `todo.text`, `mergeTodo` is called with a new text field when the input changes, and `saveTodo` is called when the form is submitted, persisting the new todo to the ledger.
+Here is the code that renders the form. The common React pattern described above is used here: the input field is bound to `todo.text`, `mergeTodo` is called with a new text field when the input changes, and `saveTodo` is called when the form is submitted, persisting the new todo to the database.
 
 ```tsx
 <div>

--- a/docs/react-tutorial.md
+++ b/docs/react-tutorial.md
@@ -54,9 +54,9 @@ In this app, we use the top-level `useLiveQuery` hook to auto-refresh query resp
 
 ### Import the Hooks
 
-The first step is to import the hooks into your new app. In `src/App.js`, add the following line to the top of the file:
+The first step is to import the hooks into your new app. In `src/App.tsx`, add the following line to the top of the file:
 
-```js
+```tsx
 import { useFireproof } from 'use-fireproof'
 ```
 
@@ -68,7 +68,7 @@ Fireproof takes a build-first approach, so after your UI is running, you can con
 
 Now, inside of your component, you can get the hooks from `useFireproof` and use `useLiveQuery` to get a list of todos (it will start empty):
 
-```js
+```tsx
 function App() {
   const { useLiveQuery } = useFireproof("my-todo-app")
   const response = useLiveQuery('date', {limit: 10, descending: true})
@@ -80,9 +80,9 @@ In short, this is indexing the ledger by the `date` field, and will ignore any d
 The `useLiveQuery` hook will automatically refresh the `response` object when the ledger changes. The response object contains the `docs` array, which is the list of todos. The response also has `rows` which are the index rows, in this case they will have a `key` with the `date` field of the todo, and an `id` field with the document id of the todo. In more complex applications you can customize the `value` of these rows, for instance to provide full-name from first and last. [Read more about indexes and queries in the documentation.](/docs/database-api/index-query)
 
 
-In our application, the todos are displayed by the following JSX, which renders their `text` field. The event handler for updating the todo is written inline. Notice how `database.put` is used to toggle the `completed` field when the checkbox is clicked:
+In our application, the todos are displayed with the following code, which renders their `text` field. The event handler for updating the todo is written inline. Notice how `database.put` is used to toggle the `completed` field when the checkbox is clicked:
 
-```jsx
+```tsx
 <ul>
   {todos.map(todo => (
     <li key={todo._id}>
@@ -103,7 +103,7 @@ For convenience, the `database` object is attached to the `useLiveQuery` and `us
 
 Next, we'll add a form to create new todos. Notice how we get `useDocument` from `useFireproof` and call it with a callback that returns the initial document state:
 
-```js
+```tsx
 const { useDocument } = useFireproof("my-todo-app")
 const { doc: todo, merge: mergeTodo, save: saveTodo, reset: resetTodo } = useDocument(() => ({
     text: "",
@@ -118,9 +118,9 @@ The `useDocument` hook is used to create a new document with an empty `text` fie
 
 ### Save the Todo
 
-Here is the JSX that renders the form. The common React pattern described above is used here: the input field is bound to `todo.text`, `mergeTodo` is called with a new text field when the input changes, and `saveTodo` is called when the form is submitted, persisting the new todo to the ledger.
+Here is the code that renders the form. The common React pattern described above is used here: the input field is bound to `todo.text`, `mergeTodo` is called with a new text field when the input changes, and `saveTodo` is called when the form is submitted, persisting the new todo to the ledger.
 
-```jsx
+```tsx
 <div>
   <input 
     type="text" 
@@ -147,7 +147,7 @@ Once your data is replicated to the cloud, you can view and edit it with the Fir
 
 ## The Completed App
 
-Here's the example to-do list that initializes the ledger and sets up automatic refresh for query results. The list of todos will redraw for all users in real-time. Replace the code in `src/App.js` with the following:
+Here's the example to-do list that initializes the ledger and sets up automatic refresh for query results. The list of todos will redraw for all users in real-time. Replace the code in `src/App.tsx` with the following:
 
 ```tsx
 import { useFireproof } from "use-fireproof";

--- a/docs/react-tutorial.md
+++ b/docs/react-tutorial.md
@@ -66,18 +66,18 @@ Fireproof takes a build-first approach, so after your UI is running, you can con
 
 ### Query Todos
 
-Now, inside of your component, you can get the hooks from `useFireproof` and use `useLiveQuery` to get a list of todos (it will start empty):
+Now, inside of your component, you can get the hooks from `useFireproof` and use `useLiveQuery` to get a list of todos (it will start empty). We'll also grab `database` so we can update a todo with `database.put`.
 
 ```tsx
 function App() {
-  const { useLiveQuery } = useFireproof("my-todo-app")
+  const { useLiveQuery, database } = useFireproof("my-todo-app")
   const response = useLiveQuery('date', {limit: 10, descending: true})
   const todos = response.docs
 ```
 
-In short, this is indexing the ledger by the `date` field, and will ignore any documents that don't have a `date` field. Queries will be sorted by `date`. Learn more about queries in the [index and query documentation](/docs/database-api/index-query).
+In short, this is indexing the database by the `date` field, and will ignore any documents that don't have a `date` field. Queries will be sorted by `date`. Learn more about queries in the [index and query documentation](/docs/database-api/index-query).
 
-The `useLiveQuery` hook will automatically refresh the `response` object when the ledger changes. The response object contains the `docs` array, which is the list of todos. The response also has `rows` which are the index rows, in this case they will have a `key` with the `date` field of the todo, and an `id` field with the document id of the todo. In more complex applications you can customize the `value` of these rows, for instance to provide full-name from first and last. [Read more about indexes and queries in the documentation.](/docs/database-api/index-query)
+The `useLiveQuery` hook will automatically refresh the `response` object when the database changes. The response object contains the `docs` array, which is the list of todos. The response also has `rows` which are the index rows, in this case they will have a `key` with the `date` field of the todo, and an `id` field with the document id of the todo. In more complex applications you can customize the `value` of these rows, for instance to provide full-name from first and last. [Read more about indexes and queries in the documentation.](/docs/database-api/index-query)
 
 
 In our application, the todos are displayed with the following code, which renders their `text` field. The event handler for updating the todo is written inline. Notice how `database.put` is used to toggle the `completed` field when the checkbox is clicked:
@@ -89,7 +89,7 @@ In our application, the todos are displayed with the following code, which rende
       <input
         type="checkbox"
         checked={todo.completed}
-        onChange={() => useLiveQuery.ledger.put({ ...todo, completed: !todo.completed })}
+        onChange={() => database.put({ ...todo, completed: !todo.completed })}
       />
       {todo.text}
     </li>
@@ -101,10 +101,16 @@ For convenience, the `database` object is attached to the `useLiveQuery` and `us
 
 ### Create a New Todo
 
-Next, we'll add a form to create new todos. Notice how we get `useDocument` from `useFireproof` and call it with a callback that returns the initial document state:
+Next, we'll add a form to create new todos. First we'll update our`useFireproof` line to also get `useDocument`.
 
 ```tsx
-const { useDocument } = useFireproof("my-todo-app")
+const { useLiveQuery, database, useDocument } = useFireproof("my-todo-app")
+```
+
+Then we'll call `useDocument` with a callback that returns the initial document state:
+
+```tsx
+
 const { doc: todo, merge: mergeTodo, save: saveTodo, reset: resetTodo } = useDocument(() => ({
     text: "",
     date: Date.now(),
@@ -147,7 +153,7 @@ Once your data is replicated to the cloud, you can view and edit it with the Fir
 
 ## The Completed App
 
-Here's the example to-do list that initializes the ledger and sets up automatic refresh for query results. The list of todos will redraw for all users in real-time. Replace the code in `src/App.tsx` with the following:
+Here's the example to-do list that initializes the database and sets up automatic refresh for query results. The list of todos will redraw for all users in real-time. Replace the code in `src/App.tsx` with the following:
 
 ```tsx
 import { useFireproof } from "use-fireproof";


### PR DESCRIPTION
Before this change, the tutorial:

* Still had some references to js/jsx despite the vite create step implying to use TypeScript.
* Called for `useLiveQuery.ledger.put` which does not exist.
* Called the `database` (which is what the `useFireproof` API calls it) a "ledger," which is confusing.

After this change:

* js/jsx is ts/tsx.
* We're using `database` from the `useFireproof` API.
* We're coalescing on "database" as the term to use instead of "ledger."