### PR TITLE
Fix typo on homepage

### DIFF
--- a/src/components/HomepageAppsSection/index.jsx
+++ b/src/components/HomepageAppsSection/index.jsx
@@ -11,7 +11,7 @@ export default function HomepageAppsSection() {
       <p className={`${common.text} ${s.applicationsTest}`}>
         Perfect for AI code generation with no setup required. Ideal for ChatGPT quick starts and code sandbox demos.{' '}
         <br className={s.applicationsBr}/>
-        For React developers, check out the <Link to='/docs/react-tutorial'>seLiveQuery tutorial</Link>{' '}
+        For React developers, check out the <Link to='/docs/react-tutorial'>useLiveQuery tutorial</Link>{' '}
         for the recommended auto-refresh APIs. Get started by writing features, and <Link to='/docs/database-api/replication'>connect to the cloud</Link> after your app is awesome.
       </p>
       <ul className={s.appsList}>


### PR DESCRIPTION
Noticed a small typo in the react docs link while diving in, fixes `seLiveQuery` → `useLiveQuery`.